### PR TITLE
chore: release 2025.01.25

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,0 +1,10 @@
+### 2025.01.25
+
+#### @hertzg/wg-ini 0.1.0 (minor)
+
+- chore(wg-ini): ser version manually to 0.1.0
+
+#### @hertzg/wg-keys 0.1.1 (patch)
+
+- chore(*): deno fmt
+- chore(*): update lockfiles

--- a/ini/deno.json
+++ b/ini/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/wg-ini",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "exports": "./mod.ts",
   "tasks": {
     "dev": "deno test --watch mod.ts"

--- a/keys/deno.json
+++ b/keys/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/wg-keys",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "exports": "./mod.ts",
   "tasks": {
     "dev": "deno test --watch mod.ts",


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|wg-ini|0.0.1|0.1.1|minor|
|@hertzg/wg-keys|0.1.0|0.1.1|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly







The following commits are ignored:

- [chore: update workflow](/hertzg/wg-tools/commit/4e4ba6b1d6525794534db5e469c4c223a3edefed)
- [chore: use github environment vars](/hertzg/wg-tools/commit/eaa3f28e5d028f7b51d9802d3463822caeaac573)
- [chore: update setup-deno action to v2](/hertzg/wg-tools/commit/43ffb8c26483a1d199f9f822fab5ec74ba452b51)

---

To make edits to this PR:

```sh
git fetch upstream release-2025-01-25-19-27-45 && git checkout -b release-2025-01-25-19-27-45 upstream/release-2025-01-25-19-27-45
```
