### PR TITLE
chore: release 2025.01.25

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,0 +1,12 @@
+### 2025.01.25
+
+#### @hertzg/wg-ini 0.1.0 (minor)
+
+- chore(wg-ini): ser version manually to 0.1.0
+
+#### @hertzg/wg-keys 0.1.1 (patch)
+
+- chore(*): update lockfile
+- chore(*): exclude ignored paths
+- chore(*): deno fmt
+- chore(*): update lockfiles

--- a/keys/deno.json
+++ b/keys/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/wg-keys",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "exports": "./mod.ts",
   "tasks": {
     "dev": "deno test --watch mod.ts",


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|wg-ini|0.0.1|0.1.0|minor|
|@hertzg/wg-keys|0.1.0|0.1.1|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly



The following commits have unknown scopes. Please handle them manually if necessary:

- [chore(keys): remove readme](/hertzg/wg-tools/commit/4aab4b9117255307719b2235a6ddcee85bbc1239)
- [chore(ini): include only mod.ts](/hertzg/wg-tools/commit/efaa25bed20c5bb3c7a4cce7e03bf48d5cd86789)
- [fix(keys): only include mod.ts](/hertzg/wg-tools/commit/761119902032425b38d019ac288ec262e50f1110)
- [fix(keys): jsdoc tests](/hertzg/wg-tools/commit/3b50fb22cf58f40b221fe701b7633aa259f05524)

Required scopes are missing in the following commits. Please handle them manually if necessary:

- [fix: docs](/hertzg/wg-tools/commit/80509832e4a238d2ca9073a81536418c608cdcfa)

The following commits are ignored:

- [chore: validate pr title](/hertzg/wg-tools/commit/ad8060a8b0d991afa8124c89aab7d705936636e7)
- [chore: add publish workflow](/hertzg/wg-tools/commit/7a53497e986ee18200460e93c629fdbc58632027)
- [chore: add ci for lint and test with coverage](/hertzg/wg-tools/commit/8309022ba829e35da1fbf05cc07fe6f563befd99)
- [chore: ci pr-labeler](/hertzg/wg-tools/commit/fcac9f0238a7f21420e6e40d9b6296013efcfc89)
- [chore: update workflow](/hertzg/wg-tools/commit/4e4ba6b1d6525794534db5e469c4c223a3edefed)
- [chore: use github environment vars](/hertzg/wg-tools/commit/eaa3f28e5d028f7b51d9802d3463822caeaac573)
- [chore: update setup-deno action to v2](/hertzg/wg-tools/commit/43ffb8c26483a1d199f9f822fab5ec74ba452b51)

---

To make edits to this PR:

```sh
git fetch upstream release-2025-01-25-20-15-42 && git checkout -b release-2025-01-25-20-15-42 upstream/release-2025-01-25-20-15-42
```
