### PR TITLE
chore: release 2025.01.25

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,5 +1,15 @@
 ### 2025.01.25
 
+#### @hertzg/wg-ini 0.1.1 (patch)
+
+- chore(*): force release
+
+#### @hertzg/wg-keys 0.1.2 (patch)
+
+- chore(*): force release
+
+### 2025.01.25
+
 #### @hertzg/wg-ini 0.1.0 (minor)
 
 - chore(wg-ini): ser version manually to 0.1.0

--- a/ini/deno.json
+++ b/ini/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/wg-ini",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "exports": "./mod.ts",
   "tasks": {
     "dev": "deno test --watch mod.ts"

--- a/keys/deno.json
+++ b/keys/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/wg-keys",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "exports": "./mod.ts",
   "tasks": {
     "dev": "deno test --watch mod.ts",


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@hertzg/wg-ini|0.1.0|0.1.1|patch|
|@hertzg/wg-keys|0.1.1|0.1.2|patch|

Please ensure:
- [x] Versions in deno.json files are updated correctly
- [x] Releases.md is updated correctly







The following commits are ignored:

- [chore: install wireguard-tools needed for tests before releasing](/hertzg/wg-tools/commit/bb76ef71a267a1e10320c26e42471b7ddc5d903e)

---

To make edits to this PR:

```sh
git fetch upstream release-2025-01-25-20-33-56 && git checkout -b release-2025-01-25-20-33-56 upstream/release-2025-01-25-20-33-56
```
